### PR TITLE
Limit the max number of POIs loaded

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -29,6 +29,8 @@ class NodesController < ApplicationController
   def index
     normalize_bbox if params[:bbox]
     @limit = params[:limit].try(:to_i) || 300
+    # Allow max 1000 Pois per request.
+    @limit = [@limit, 1000].min
     
     @places = Poi.within_bbox(@left, @bottom, @right, @top).with_associations.limit(@limit) if @left
     # If a node_id is given and could be found, make sure it is included in the collection


### PR DESCRIPTION
The param limit didn't have an upper border (just a default value). 
This will prevent a very simple DOS attack, using the limit with a very large number and running concurrently.